### PR TITLE
update info.xml

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,11 +12,11 @@
     <author>Tom Singer</author>
     <email>tomsinger@gmail.com</email>
   </maintainer>
-  <releaseDate>2014-08-13</releaseDate>
-  <version>1.1</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2018-12-05</releaseDate>
+  <version>1.2</version>
+  <develStage>beta</develStage>
   <compatibility>
-    <ver>4.4</ver>
+    <ver>5.0</ver>
   </compatibility>
   <comments>Support is via Github issues - Pull Requests always welcomed!</comments>
   <civix>


### PR DESCRIPTION
Updating the `info.xml` will give folks increased confidence that this has seen some recent love.  Setting a minimum version of 5.0 is intended to reflect the fact that I included some PHP 5.4-isms in my latest PRs.  I expect this will work with 4.4+ if you're running PHP 5.4+, but I don't think it pays to advertise that :smile: 